### PR TITLE
set up logging

### DIFF
--- a/src/streamlit_analytics2/__init__.py
+++ b/src/streamlit_analytics2/__init__.py
@@ -1,3 +1,6 @@
 from .main import counts, start_tracking, stop_tracking, track  # noqa: F401
+import logging
 
 __version__ = "0.8.7"
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/streamlit_analytics2/main.py
+++ b/src/streamlit_analytics2/main.py
@@ -23,7 +23,9 @@ from .utils import replace_empty
 # as modules are only imported once by a streamlit app.
 counts = {"loaded_from_firestore": False}
 
-logging.info("SA2: Streamlit-analytics2 successfully imported")
+logger = logging.getLogger(__name__)
+
+logger.info("SA2: Streamlit-analytics2 successfully imported")
 
 
 def reset_counts():
@@ -332,18 +334,18 @@ def start_tracking(
             counts.update({k: json_counts[k] for k in json_counts if k in counts})
 
             if verbose:
-                logging.info(f"{log_msg_prefix}{load_from_json}")
-                logging.info("SA2: Success! Loaded counts:")
-                logging.info(counts)
+                logger.info(f"{log_msg_prefix}{load_from_json}")
+                logger.info("SA2: Success! Loaded counts:")
+                logger.info(counts)
 
         except FileNotFoundError:
             if verbose:
-                logging.warning(
+                logger.warning(
                     f"SA2: File {load_from_json} not found, proceeding with empty counts."
                 )
         except Exception as e:
             # Catch-all for any other exceptions, log the error
-            logging.error(f"SA2: Error loading counts from {load_from_json}: {e}")
+            logger.error(f"SA2: Error loading counts from {load_from_json}: {e}")
 
     # Reset session state.
     if "user_tracked" not in st.session_state:
@@ -416,7 +418,7 @@ def start_tracking(
     # }
 
     if verbose:
-        logging.info("\nSA2: Tracking script execution with streamlit-analytics...")
+        logger.info("\nSA2: Tracking script execution with streamlit-analytics...")
 
 
 def stop_tracking(
@@ -437,11 +439,11 @@ def stop_tracking(
     """
 
     if verbose:
-        logging.info("SA2: Finished script execution. New counts:")
-        logging.info(
+        logger.info("SA2: Finished script execution. New counts:")
+        logger.info(
             "%s", counts
         )  # Use %s and pass counts to logging to handle complex objects
-        logging.info("%s", "-" * 80)  # For separators or multi-line messages
+        logger.info("%s", "-" * 80)  # For separators or multi-line messages
 
     # Reset streamlit functions.
     st.button = _orig_button


### PR DESCRIPTION
# Pull Request Template

## TL;DR
- Set up logging for streamlitanalytics2 properly with `getLogger()`
- Used urllib3 as a reference for how logging should be set up in a library

## Problem Solved
1. When using streamlitanalytics2 and another library that has logging, info messages were being printed to the console when logging was not configured to do that.

## Changes Made(Optional)
List the main changes in bullet points.
- [ ] get a logger for the library and give it a null handler

## Manual Testing
- [ ] You have manually tested all changes to ensure they work as intended. Replace the [ ] with a [X] if True.


**How was this tested?**
Describe the tests that you ran to verify your changes.
- Tested by running a streamlit app using the fork and a library with test logging INFO messages

## Additional Notes
- I used urllib3 and python's documentation as a reference for how logging should be configured in a library
- If someone wants to access the logs in streamlit-analytics2 in an application using it they'd do something like this 
```python
import streamlit_analytics2
import logging

logger = logging.getLogger("streamlit_analytics2")
logger.setLevel(logging.DEBUG)

handler = logging.StreamHandler()
handler.setLevel(logging.DEBUG)
logger.addHandler(handler)
```