### PR TITLE
fix 0.10.1 to fix KeyError

### DIFF
--- a/examples/pages/firebase_test.py
+++ b/examples/pages/firebase_test.py
@@ -12,9 +12,9 @@ with tab1:
     if st.button("Test Classic"):
 
         with streamlit_analytics.track(
-            firestore_document_name="datalyttics",
             firestore_key_file="pages/firebase-key.json",
-            firestore_collection_name="no_doc_name3",
+            firestore_collection_name="streamlit_analytics2",
+            firestore_document_name="data",
             firestore_project_name="streamlit-analtyics2",
             verbose=True,
         ):

--- a/src/streamlit_analytics2/__init__.py
+++ b/src/streamlit_analytics2/__init__.py
@@ -6,5 +6,5 @@ Track & visualize user interactions with your streamlit app.
 from .main import start_tracking, stop_tracking, track  # noqa: F401
 from .state import data  # noqa: F401
 
-__version__ = "0.10.0"
+__version__ = "0.10.1"
 __name__ = "streamlit_analytics2"


### PR DESCRIPTION
This pull request includes updates to the `examples/pages/firebase_test.py` file and a version bump in the `src/streamlit_analytics2/__init__.py` file. The most important changes are:

Updates to Firebase test configuration:

* [`examples/pages/firebase_test.py`](diffhunk://#diff-1d5be9a49b3bccea5027c0e33ad0d8ba31af640adc094e0622f440990163dcb8L15-R17): Changed the `firestore_collection_name` to "streamlit_analytics2" and the `firestore_document_name` to "data".

Version update:

* [`src/streamlit_analytics2/__init__.py`](diffhunk://#diff-9b4a3630806b652e2c3f78ff1ad799969576dc37044d33a271f999af56e7ddb3L9-R9): Updated the version from "0.10.0" to "0.10.1".## Description
