### PR TITLE
remove document from config display and bump to 10.2

### DIFF
--- a/src/streamlit_analytics2/__init__.py
+++ b/src/streamlit_analytics2/__init__.py
@@ -6,5 +6,5 @@ Track & visualize user interactions with your streamlit app.
 from .main import start_tracking, stop_tracking, track  # noqa: F401
 from .state import data  # noqa: F401
 
-__version__ = "0.10.1"
+__version__ = "0.10.2"
 __name__ = "streamlit_analytics2"

--- a/src/streamlit_analytics2/config.py
+++ b/src/streamlit_analytics2/config.py
@@ -26,7 +26,7 @@ DEFAULT_CONFIG = {
         "firestore_key_file": "firebase-key.json",
         "firestore_project_name": "",
         "firestore_collection_name": "streamlit_analytics2",
-        "firestore_document_name": "data",
+        # "firestore_document_name": "data",
         "streamlit_secrets_firestore_key": "",
     },
     "session": {"session_id": ""},
@@ -138,10 +138,10 @@ def show_config():
         "Firestore Collection Name",
         value=config["firestore"]["firestore_collection_name"],
     )
-    firestore_document = st.text_input(
-        "Firestore Document Name",
-        value=config["firestore"]["firestore_document_name"],
-    )
+    # firestore_document = st.text_input(
+    #     "Firestore Document Name",
+    #     value=config["firestore"]["firestore_document_name"],
+    # )
     firestore_secret_key = st.text_input(
         "Firestore Secret Key",
         value=config["firestore"]["streamlit_secrets_firestore_key"],
@@ -167,7 +167,7 @@ def show_config():
             "firestore_key_file": firestore_key_file,
             "firestore_project_name": firestore_project,
             "firestore_collection_name": firestore_collection,
-            "firestore_document_name": firestore_document,
+            # "firestore_document_name": firestore_document,
             "streamlit_secrets_firestore_key": firestore_secret_key,
         },
         "session": {"session_id": session_id},


### PR DESCRIPTION
This pull request includes updates to the version number and modifications to the Firestore configuration in the `streamlit_analytics2` package. The most important changes are as follows:

Version update:
* [`src/streamlit_analytics2/__init__.py`](diffhunk://#diff-9b4a3630806b652e2c3f78ff1ad799969576dc37044d33a271f999af56e7ddb3L9-R9): Updated the version number from "0.10.1" to "0.10.2".

Firestore configuration changes:
* [`src/streamlit_analytics2/config.py`](diffhunk://#diff-22045bd190c1ae3695143e859591b51699408b28dfe9a986a202689d6d193310L29-R29): Commented out the `firestore_document_name` configuration setting and its usage in the `show_config` function. [[1]](diffhunk://#diff-22045bd190c1ae3695143e859591b51699408b28dfe9a986a202689d6d193310L29-R29) [[2]](diffhunk://#diff-22045bd190c1ae3695143e859591b51699408b28dfe9a986a202689d6d193310L141-R144) [[3]](diffhunk://#diff-22045bd190c1ae3695143e859591b51699408b28dfe9a986a202689d6d193310L170-R170)